### PR TITLE
Don't special-case self-alignments

### DIFF
--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -101,8 +101,6 @@
          '$fastq_input.fastq_input1' '$fastq_input.fastq_input2'
     #else if $fastq_input.fastq_input_selector == 'paired_collection':
          '$fastq_input.fastq_input1.forward' '$fastq_input.fastq_input1.reverse'
-    #else if $fastq_input.fastq_input_selector == 'self_mapping':
-         'reference.fa'
     #end if
     #if $io_options.output_format == 'BAM':
         -a
@@ -124,7 +122,7 @@
     </command>
     <inputs>
         <conditional name="reference_source">
-            <param name="reference_source_selector" type="select" label="Will you select a reference genome from your history or use a built-in index?" help="Built-ins were indexed using default options. See `Indexes` section of help below">
+            <param name="reference_source_selector" type="select" label="Will you select a reference genome from your history or use a built-in index?" help="Built-ins were indexed using default options. See `Indexes` section of help below. If you would like to perform self-mapping select `history` here, then choose your input file as reference.">
                 <option value="cached">Use a built-in genome index</option>
                 <option value="history">Use a genome from history and build index</option>
             </param>
@@ -156,7 +154,6 @@
                 <option value="paired">Paired</option>
                 <option value="paired_collection">Paired Collection</option>
                 <option value="paired_iv">Paired Interleaved</option>
-                <option value="self_mapping">Reference file</option>
             </param>
             <when value="paired">
                 <param name="fastq_input1" type="data" format="fastqsanger,fastqsanger.gz,fasta" label="Select first set of reads" help="Specify dataset with forward reads"/>
@@ -170,8 +167,6 @@
             </when>
             <when value="paired_iv">
                 <param name="fastq_input1" type="data" format="fastqsanger,fastqsanger.gz,fasta" label="Select fastq dataset" help="Specify dataset with interleaved reads"/>
-            </when>
-            <when value="self_mapping">
             </when>
         </conditional>
         <!-- end unchanged copy from bwa-mem -->
@@ -213,7 +208,7 @@
             </param>
         </section>
         <section name="io_options" title="Set advanced output options" help="Sets -Q, -L, -R, -c, --cs and -K options." expanded="False">
-            <param name="output_format" type="select" label="Produce BAM or CRAM file?">
+            <param name="output_format" type="select" label="Select an output format">
                 <option value="BAM">BAM</option>
                 <option value="CRAM">CRAM</option>
                 <option value="paf">paf</option>
@@ -249,7 +244,7 @@
                 </conditional>
             </actions>
             <change_format>
-                <when input="io_options.output_format" value="paf" format="interval" />
+                <when input="io_options.output_format" value="paf" format="tabular" />
                 <when input="io_options.output_format" value="CRAM" format="cram" />
             </change_format>
         </data>
@@ -321,10 +316,11 @@
             <!-- test paf output -->
             <param name="reference_source_selector" value="history" />
             <param name="ref_file" ftype="fastqsanger"  value="mini_reads.fq" />
-            <param name="fastq_input_selector" value="self_mapping"/>
+            <param name="fastq_input_selector" value="single"/>
+            <param name="fastq_input1" ftype="fastqsanger"  value="mini_reads.fq" />
             <param name="analysis_type_selector" value="ava-ont"/>
             <param name="output_format" value="paf"/>
-            <output name="alignment_output" ftype="interval" file="mini_reads.paf" />
+            <output name="alignment_output" ftype="tabular" file="mini_reads.paf" />
         </test>
     </tests>
     <help>


### PR DESCRIPTION
This avoids putting the self-mapping mode into the reference_source_selector, and also changes interval to tabular, as PAF isn't a valid subtype of Interval. We can then add the paf datatype to galaxy that is just subclassed from tabular.